### PR TITLE
fix: use relative nav links for GitHub Pages routing

### DIFF
--- a/demo/HeroWave.Demo/Pages/FullPage.razor
+++ b/demo/HeroWave.Demo/Pages/FullPage.razor
@@ -12,7 +12,7 @@
         <p style="font-size: 1.25rem; color: rgba(255,255,255,0.7); margin-bottom: 2rem;">
             Custom colors, more waves, faster animation
         </p>
-        <a href="/"
+        <a href="./"
            style="padding: 0.75rem 2rem; background: rgba(255,255,255,0.15);
                   color: white; border-radius: 0.5rem; text-decoration: none;
                   border: 1px solid rgba(255,255,255,0.3);">

--- a/demo/HeroWave.Demo/Pages/Home.razor
+++ b/demo/HeroWave.Demo/Pages/Home.razor
@@ -3,7 +3,7 @@
 <WavyBackground Title="Build Amazing Apps"
                 Subtitle="A reusable wavy background component for Blazor"
                 Height="60vh">
-    <a href="/fullpage"
+    <a href="fullpage"
        style="padding: 0.75rem 2rem; background: white; color: #0c0c14;
               border-radius: 0.5rem; text-decoration: none; font-weight: 600;">
         View Full Page Demo

--- a/demo/HeroWave.Demo/Pages/Showcase.razor
+++ b/demo/HeroWave.Demo/Pages/Showcase.razor
@@ -78,7 +78,7 @@
 </WavyBackground>
 
 <div style="text-align: center; padding: 2rem;">
-    <a href="/"
+    <a href="./"
        style="padding: 0.75rem 2rem; background: rgba(255,255,255,0.1);
               color: white; border-radius: 0.5rem; text-decoration: none;
               border: 1px solid rgba(255,255,255,0.2);">


### PR DESCRIPTION
## Summary
- Fix demo page navigation links to use relative paths instead of absolute paths
- Absolute paths like `href="/fullpage"` bypass the `<base href="/hero-wave/">` and 404 on GitHub Pages
- Changed to relative paths (`href="fullpage"`, `href="./"`) which work in both local dev and deployed environments

## Test plan
- [ ] Merge, tag, and verify navigation between all three demo pages on GitHub Pages
- [ ] Verify local `dotnet run` still navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)