### PR TITLE
fix: GitHub Pages routing and demo animation speed

### DIFF
--- a/demo/HeroWave.Demo/Pages/FullPage.razor
+++ b/demo/HeroWave.Demo/Pages/FullPage.razor
@@ -1,7 +1,7 @@
 @page "/fullpage"
 
 <WavyBackground Height="100vh"
-                Speed="0.008"
+                Speed="0.004"
                 Colors="@(new[] { "#22d3ee", "#818cf8", "#e879f9" })"
                 WaveCount="7"
                 Opacity="0.6">

--- a/demo/HeroWave.Demo/Pages/Home.razor
+++ b/demo/HeroWave.Demo/Pages/Home.razor
@@ -2,7 +2,8 @@
 
 <WavyBackground Title="Build Amazing Apps"
                 Subtitle="A reusable wavy background component for Blazor"
-                Height="60vh">
+                Height="60vh"
+                Speed="0.002">
     <a href="fullpage"
        style="padding: 0.75rem 2rem; background: white; color: #0c0c14;
               border-radius: 0.5rem; text-decoration: none; font-weight: 600;">

--- a/demo/HeroWave.Demo/Pages/Showcase.razor
+++ b/demo/HeroWave.Demo/Pages/Showcase.razor
@@ -12,7 +12,7 @@
                 BackgroundColor="#021a2b"
                 WaveCount="6"
                 WaveWidth="60"
-                Speed="0.004"
+                Speed="0.002"
                 Opacity="0.6">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Deep sea calm</p>
 </WavyBackground>
@@ -24,7 +24,7 @@
                 BackgroundColor="#1a0a00"
                 WaveCount="5"
                 WaveWidth="45"
-                Speed="0.008"
+                Speed="0.004"
                 Opacity="0.55">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Warm & energetic</p>
 </WavyBackground>
@@ -36,7 +36,7 @@
                 BackgroundColor="#0a0a0a"
                 WaveCount="4"
                 WaveWidth="35"
-                Speed="0.008"
+                Speed="0.004"
                 Opacity="0.7">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Electric & bold</p>
 </WavyBackground>
@@ -48,7 +48,7 @@
                 BackgroundColor="#0f172a"
                 WaveCount="3"
                 WaveWidth="70"
-                Speed="0.004"
+                Speed="0.002"
                 Opacity="0.3">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Clean & elegant</p>
 </WavyBackground>
@@ -60,7 +60,7 @@
                 BackgroundColor="#0c0720"
                 WaveCount="7"
                 WaveWidth="55"
-                Speed="0.004"
+                Speed="0.002"
                 Opacity="0.5">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Ethereal glow</p>
 </WavyBackground>
@@ -72,7 +72,7 @@
                 BackgroundColor="#1c1208"
                 WaveCount="5"
                 WaveWidth="55"
-                Speed="0.008"
+                Speed="0.004"
                 Opacity="0.45">
     <p style="color: white; font-size: 1.5rem; font-weight: 600;">Premium & rich</p>
 </WavyBackground>


### PR DESCRIPTION
## Summary
- Fix demo nav links to use relative paths (`href="fullpage"` instead of `href="/fullpage"`) so routing works with the `/hero-wave/` base href on GitHub Pages
- Halve animation speed across all demo pages for a smoother visual experience

## Test plan
- [ ] Merge, tag, and verify navigation between all three demo pages on GitHub Pages
- [ ] Verify animations run at a comfortable speed
- [ ] Verify local `dotnet run` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)