### PR TITLE
fix: remove benchmark link from demo home page

### DIFF
--- a/demo/HeroWave.Demo/Pages/Home.razor
+++ b/demo/HeroWave.Demo/Pages/Home.razor
@@ -9,12 +9,7 @@
               border-radius: 0.5rem; text-decoration: none; font-weight: 600;">
         View Full Page Demo
     </a>
-    <a href="/benchmark"
-       style="padding: 0.75rem 2rem; background: rgba(255,255,255,0.15); color: white;
-              border-radius: 0.5rem; text-decoration: none; font-weight: 600;
-              border: 1px solid rgba(255,255,255,0.3); margin-top: 0.75rem;">
-        Benchmark Optimizations
-    </a>
+
 </WavyBackground>
 
 <div style="padding: 4rem 2rem; color: white; text-align: center;">


### PR DESCRIPTION
## Summary
- Remove the "Benchmark Optimizations" link from the demo home page — it was added during development and shouldn't be in production

## Test plan
- [ ] Verify `/` only shows "View Full Page Demo" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)