### PR TITLE
feat: add typed preset system with IntelliSense support

### DIFF
--- a/src/HeroWave/Components/WavePresets.cs
+++ b/src/HeroWave/Components/WavePresets.cs
@@ -1,0 +1,111 @@
+namespace HeroWave.Components;
+
+/// <summary>
+/// Predefined wave configuration with curated colors and settings.
+/// Use with <see cref="WavyBackground.Preset"/> and override individual
+/// component parameters as needed.
+/// </summary>
+/// <example>
+/// <code>
+/// &lt;WavyBackground Preset="WavePresets.OceanAurora" Speed="0.008" /&gt;
+/// </code>
+/// </example>
+public record WavePresetConfig
+{
+    /// <summary>
+    /// CSS color strings for each wave. Cycled if fewer than <see cref="WaveCount"/>.
+    /// </summary>
+    public string[] Colors { get; init; } = ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"];
+
+    /// <summary>
+    /// Background color of the canvas.
+    /// </summary>
+    public string BackgroundColor { get; init; } = "#0c0c14";
+
+    /// <summary>
+    /// Number of wave lines to render.
+    /// </summary>
+    public int WaveCount { get; init; } = 5;
+
+    /// <summary>
+    /// Base stroke width of each wave in CSS pixels.
+    /// </summary>
+    public int WaveWidth { get; init; } = 50;
+
+    /// <summary>
+    /// Animation speed. Higher values = faster waves.
+    /// </summary>
+    public double Speed { get; init; } = 0.004;
+
+    /// <summary>
+    /// Wave opacity multiplier (0.0 – 1.0).
+    /// </summary>
+    public double Opacity { get; init; } = 0.5;
+}
+
+/// <summary>
+/// Named presets with curated color palettes.
+/// </summary>
+public static class WavePresets
+{
+    /// <summary>Default HeroWave palette — blue, purple, pink, cyan.</summary>
+    public static WavePresetConfig Default { get; } = new();
+
+    /// <summary>Cool blues and greens — oceanic aurora feel.</summary>
+    public static WavePresetConfig OceanAurora { get; } = new()
+    {
+        Colors = ["#0ea5e9", "#06b6d4", "#14b8a6", "#10b981", "#34d399"],
+        BackgroundColor = "#021a2b",
+        WaveCount = 6,
+        WaveWidth = 60,
+        Opacity = 0.6,
+    };
+
+    /// <summary>Warm oranges, reds, and pinks — fiery sunset tones.</summary>
+    public static WavePresetConfig SunsetFire { get; } = new()
+    {
+        Colors = ["#f97316", "#ef4444", "#ec4899", "#f59e0b", "#fb923c"],
+        BackgroundColor = "#1a0a00",
+        Speed = 0.008,
+        Opacity = 0.55,
+    };
+
+    /// <summary>Electric high-contrast neon on dark background.</summary>
+    public static WavePresetConfig NeonCyberpunk { get; } = new()
+    {
+        Colors = ["#ff00ff", "#00ffff", "#39ff14", "#ff3131"],
+        BackgroundColor = "#0a0a0a",
+        WaveCount = 4,
+        WaveWidth = 35,
+        Speed = 0.008,
+        Opacity = 0.7,
+    };
+
+    /// <summary>Subtle white and silver on dark blue — minimal and clean.</summary>
+    public static WavePresetConfig MinimalFrost { get; } = new()
+    {
+        Colors = ["#e2e8f0", "#94a3b8", "#cbd5e1", "#f1f5f9"],
+        BackgroundColor = "#0f172a",
+        WaveCount = 3,
+        WaveWidth = 70,
+        Opacity = 0.3,
+    };
+
+    /// <summary>Purples, greens, and ethereal blues — northern lights atmosphere.</summary>
+    public static WavePresetConfig NorthernLights { get; } = new()
+    {
+        Colors = ["#a855f7", "#6366f1", "#22d3ee", "#4ade80", "#818cf8"],
+        BackgroundColor = "#0c0720",
+        WaveCount = 7,
+        WaveWidth = 55,
+    };
+
+    /// <summary>Luxurious golds and ambers on deep warm dark.</summary>
+    public static WavePresetConfig MoltenGold { get; } = new()
+    {
+        Colors = ["#fbbf24", "#f59e0b", "#d97706", "#b45309", "#fcd34d"],
+        BackgroundColor = "#1c1208",
+        Speed = 0.008,
+        Opacity = 0.45,
+    };
+}

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -29,37 +29,51 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     [Parameter] public string Height { get; set; } = "100vh";
 
     /// <summary>
+    /// Apply a named preset configuration. Individual parameters below override
+    /// the preset values when explicitly set.
+    /// </summary>
+    /// <example>
+    /// <code>&lt;WavyBackground Preset="WavePresets.OceanAurora" Speed="0.008" /&gt;</code>
+    /// </example>
+    [Parameter] public WavePresetConfig? Preset { get; set; }
+
+    /// <summary>
     /// Array of CSS color strings used for each wave. Defaults to a blue-purple palette.
     /// Colors are cycled if there are fewer colors than waves.
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public string[] Colors { get; set; } =
-        ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"];
+    [Parameter] public string[]? Colors { get; set; }
 
     /// <summary>
     /// Background color of the canvas. Defaults to <c>"#0c0c14"</c> (dark).
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public string BackgroundColor { get; set; } = "#0c0c14";
+    [Parameter] public string? BackgroundColor { get; set; }
 
     /// <summary>
     /// Number of wave lines to render. Defaults to <c>5</c>.
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public int WaveCount { get; set; } = 5;
+    [Parameter] public int? WaveCount { get; set; }
 
     /// <summary>
     /// Base stroke width of each wave in CSS pixels. Defaults to <c>50</c>.
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public int WaveWidth { get; set; } = 50;
+    [Parameter] public int? WaveWidth { get; set; }
 
     /// <summary>
     /// Animation speed. Defaults to <c>0.004</c>. Higher values = faster waves.
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public double Speed { get; set; } = 0.004;
+    [Parameter] public double? Speed { get; set; }
 
     /// <summary>
     /// Wave opacity multiplier. Defaults to <c>0.5</c>.
     /// Controls the overall visibility of the waves.
+    /// Overrides the preset value when set explicitly.
     /// </summary>
-    [Parameter] public double Opacity { get; set; } = 0.5;
+    [Parameter] public double? Opacity { get; set; }
 
     /// <summary>
     /// Optional CSS class applied to the text overlay container.
@@ -70,6 +84,17 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private IJSObjectReference? _module;
     private string? _instanceId;
 
+    private string[] ResolvedColors =>
+        Colors ?? Preset?.Colors ?? ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"];
+
+    private string ResolvedBackgroundColor =>
+        BackgroundColor ?? Preset?.BackgroundColor ?? "#0c0c14";
+
+    private int ResolvedWaveCount => WaveCount ?? Preset?.WaveCount ?? 5;
+    private int ResolvedWaveWidth => WaveWidth ?? Preset?.WaveWidth ?? 50;
+    private double ResolvedSpeed => Speed ?? Preset?.Speed ?? 0.004;
+    private double ResolvedOpacity => Opacity ?? Preset?.Opacity ?? 0.5;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
@@ -79,12 +104,12 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
         var config = new
         {
-            colors = Colors,
-            backgroundColor = BackgroundColor,
-            waveCount = WaveCount,
-            waveWidth = WaveWidth,
-            speed = Speed,
-            opacity = Opacity
+            colors = ResolvedColors,
+            backgroundColor = ResolvedBackgroundColor,
+            waveCount = ResolvedWaveCount,
+            waveWidth = ResolvedWaveWidth,
+            speed = ResolvedSpeed,
+            opacity = ResolvedOpacity
         };
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -37,36 +37,78 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     /// </example>
     [Parameter] public WavePresetConfig? Preset { get; set; }
 
+    private string[]? _colorsOverride;
+
     /// <summary>
     /// CSS color strings for each wave, cycled if fewer than <see cref="WavePresetConfig.WaveCount"/>.
     /// When set, overrides the preset value.
     /// </summary>
-    [Parameter] public string[]? Colors { get; set; }
+    [Parameter]
+    public string[] Colors
+    {
+        get => _colorsOverride ?? Preset?.Colors ?? Defaults.Colors;
+        set => _colorsOverride = value;
+    }
+
+    private string? _backgroundColorOverride;
 
     /// <summary>
     /// Background color of the canvas. When set, overrides the preset value.
     /// </summary>
-    [Parameter] public string? BackgroundColor { get; set; }
+    [Parameter]
+    public string BackgroundColor
+    {
+        get => _backgroundColorOverride ?? Preset?.BackgroundColor ?? Defaults.BackgroundColor;
+        set => _backgroundColorOverride = value;
+    }
+
+    private int? _waveCountOverride;
 
     /// <summary>
     /// Number of wave lines to render. When set, overrides the preset value.
     /// </summary>
-    [Parameter] public int? WaveCount { get; set; }
+    [Parameter]
+    public int WaveCount
+    {
+        get => _waveCountOverride ?? Preset?.WaveCount ?? Defaults.WaveCount;
+        set => _waveCountOverride = value;
+    }
+
+    private int? _waveWidthOverride;
 
     /// <summary>
     /// Base stroke width of each wave in CSS pixels. When set, overrides the preset value.
     /// </summary>
-    [Parameter] public int? WaveWidth { get; set; }
+    [Parameter]
+    public int WaveWidth
+    {
+        get => _waveWidthOverride ?? Preset?.WaveWidth ?? Defaults.WaveWidth;
+        set => _waveWidthOverride = value;
+    }
+
+    private double? _speedOverride;
 
     /// <summary>
     /// Animation speed — higher values produce faster waves. When set, overrides the preset value.
     /// </summary>
-    [Parameter] public double? Speed { get; set; }
+    [Parameter]
+    public double Speed
+    {
+        get => _speedOverride ?? Preset?.Speed ?? Defaults.Speed;
+        set => _speedOverride = value;
+    }
+
+    private double? _opacityOverride;
 
     /// <summary>
     /// Wave opacity multiplier (0.0 – 1.0). When set, overrides the preset value.
     /// </summary>
-    [Parameter] public double? Opacity { get; set; }
+    [Parameter]
+    public double Opacity
+    {
+        get => _opacityOverride ?? Preset?.Opacity ?? Defaults.Opacity;
+        set => _opacityOverride = value;
+    }
 
     /// <summary>
     /// Optional CSS class applied to the text overlay container.
@@ -79,13 +121,6 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
     private static readonly WavePresetConfig Defaults = new();
 
-    private string[] ResolvedColors => Colors ?? Preset?.Colors ?? Defaults.Colors;
-    private string ResolvedBackgroundColor => BackgroundColor ?? Preset?.BackgroundColor ?? Defaults.BackgroundColor;
-    private int ResolvedWaveCount => WaveCount ?? Preset?.WaveCount ?? Defaults.WaveCount;
-    private int ResolvedWaveWidth => WaveWidth ?? Preset?.WaveWidth ?? Defaults.WaveWidth;
-    private double ResolvedSpeed => Speed ?? Preset?.Speed ?? Defaults.Speed;
-    private double ResolvedOpacity => Opacity ?? Preset?.Opacity ?? Defaults.Opacity;
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
@@ -95,12 +130,12 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
         var config = new
         {
-            colors = ResolvedColors,
-            backgroundColor = ResolvedBackgroundColor,
-            waveCount = ResolvedWaveCount,
-            waveWidth = ResolvedWaveWidth,
-            speed = ResolvedSpeed,
-            opacity = ResolvedOpacity
+            colors = Colors,
+            backgroundColor = BackgroundColor,
+            waveCount = WaveCount,
+            waveWidth = WaveWidth,
+            speed = Speed,
+            opacity = Opacity
         };
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -38,40 +38,33 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     [Parameter] public WavePresetConfig? Preset { get; set; }
 
     /// <summary>
-    /// Array of CSS color strings used for each wave. Defaults to a blue-purple palette.
-    /// Colors are cycled if there are fewer colors than waves.
-    /// Overrides the preset value when set explicitly.
+    /// CSS color strings for each wave, cycled if fewer than <see cref="WavePresetConfig.WaveCount"/>.
+    /// When set, overrides the preset value.
     /// </summary>
     [Parameter] public string[]? Colors { get; set; }
 
     /// <summary>
-    /// Background color of the canvas. Defaults to <c>"#0c0c14"</c> (dark).
-    /// Overrides the preset value when set explicitly.
+    /// Background color of the canvas. When set, overrides the preset value.
     /// </summary>
     [Parameter] public string? BackgroundColor { get; set; }
 
     /// <summary>
-    /// Number of wave lines to render. Defaults to <c>5</c>.
-    /// Overrides the preset value when set explicitly.
+    /// Number of wave lines to render. When set, overrides the preset value.
     /// </summary>
     [Parameter] public int? WaveCount { get; set; }
 
     /// <summary>
-    /// Base stroke width of each wave in CSS pixels. Defaults to <c>50</c>.
-    /// Overrides the preset value when set explicitly.
+    /// Base stroke width of each wave in CSS pixels. When set, overrides the preset value.
     /// </summary>
     [Parameter] public int? WaveWidth { get; set; }
 
     /// <summary>
-    /// Animation speed. Defaults to <c>0.004</c>. Higher values = faster waves.
-    /// Overrides the preset value when set explicitly.
+    /// Animation speed — higher values produce faster waves. When set, overrides the preset value.
     /// </summary>
     [Parameter] public double? Speed { get; set; }
 
     /// <summary>
-    /// Wave opacity multiplier. Defaults to <c>0.5</c>.
-    /// Controls the overall visibility of the waves.
-    /// Overrides the preset value when set explicitly.
+    /// Wave opacity multiplier (0.0 – 1.0). When set, overrides the preset value.
     /// </summary>
     [Parameter] public double? Opacity { get; set; }
 
@@ -84,16 +77,14 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private IJSObjectReference? _module;
     private string? _instanceId;
 
-    private string[] ResolvedColors =>
-        Colors ?? Preset?.Colors ?? ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"];
+    private static readonly WavePresetConfig Defaults = new();
 
-    private string ResolvedBackgroundColor =>
-        BackgroundColor ?? Preset?.BackgroundColor ?? "#0c0c14";
-
-    private int ResolvedWaveCount => WaveCount ?? Preset?.WaveCount ?? 5;
-    private int ResolvedWaveWidth => WaveWidth ?? Preset?.WaveWidth ?? 50;
-    private double ResolvedSpeed => Speed ?? Preset?.Speed ?? 0.004;
-    private double ResolvedOpacity => Opacity ?? Preset?.Opacity ?? 0.5;
+    private string[] ResolvedColors => Colors ?? Preset?.Colors ?? Defaults.Colors;
+    private string ResolvedBackgroundColor => BackgroundColor ?? Preset?.BackgroundColor ?? Defaults.BackgroundColor;
+    private int ResolvedWaveCount => WaveCount ?? Preset?.WaveCount ?? Defaults.WaveCount;
+    private int ResolvedWaveWidth => WaveWidth ?? Preset?.WaveWidth ?? Defaults.WaveWidth;
+    private double ResolvedSpeed => Speed ?? Preset?.Speed ?? Defaults.Speed;
+    private double ResolvedOpacity => Opacity ?? Preset?.Opacity ?? Defaults.Opacity;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -117,21 +108,14 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_module is not null && _instanceId is not null)
+        if (_module is null) return;
+
+        if (_instanceId is not null)
         {
-            try
-            {
-                await _module.InvokeVoidAsync("dispose", _instanceId);
-            }
-            catch (JSDisconnectedException)
-            {
-                // Circuit may already be gone during app shutdown
-            }
+            try { await _module.InvokeVoidAsync("dispose", _instanceId); }
+            catch (JSDisconnectedException) { }
         }
 
-        if (_module is not null)
-        {
-            await _module.DisposeAsync();
-        }
+        await _module.DisposeAsync();
     }
 }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -165,6 +165,9 @@ public class WavyBackgroundTests : BunitContext
         var cut = Render<WavyBackground>(p =>
             p.Add(x => x.Preset, WavePresets.OceanAurora));
 
+        // Colors getter should resolve to preset colors when no override is set
+        Assert.Equal(WavePresets.OceanAurora.Colors, cut.Instance.Colors);
+
         var initInvocations = _moduleInterop.Invocations["init"];
         Assert.Single(initInvocations);
     }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -12,7 +12,6 @@ public class WavyBackgroundTests : BunitContext
 
     public WavyBackgroundTests()
     {
-        // Set up JSInterop to handle the module import and init/dispose calls
         _moduleInterop = JSInterop.SetupModule("./_content/HeroWave/wavy-background.js");
         _moduleInterop.Setup<string>("init", _ => true).SetResult("test-instance-0");
         _moduleInterop.SetupVoid("dispose", _ => true);
@@ -203,7 +202,7 @@ public class WavyBackgroundTests : BunitContext
             WavePresets.NeonCyberpunk,
             WavePresets.MinimalFrost,
             WavePresets.NorthernLights,
-            WavePresets.MoltenGold,
+            WavePresets.MoltenGold
         };
 
         foreach (var preset in presets)
@@ -222,7 +221,6 @@ public class WavyBackgroundTests : BunitContext
         var custom = WavePresets.OceanAurora with { Speed = 0.01, WaveCount = 10 };
         Assert.Equal(0.01, custom.Speed);
         Assert.Equal(10, custom.WaveCount);
-        // Original is unchanged
         Assert.Equal(0.004, WavePresets.OceanAurora.Speed);
         Assert.Equal(6, WavePresets.OceanAurora.WaveCount);
     }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -152,4 +152,78 @@ public class WavyBackgroundTests : BunitContext
         // Should not throw
         await DisposeComponentsAsync();
     }
+
+    [Fact]
+    public void Preset_Is_Null_By_Default()
+    {
+        var cut = Render<WavyBackground>();
+        Assert.Null(cut.Instance.Preset);
+    }
+
+    [Fact]
+    public void Preset_Colors_Are_Used_When_No_Explicit_Colors()
+    {
+        var cut = Render<WavyBackground>(p =>
+            p.Add(x => x.Preset, WavePresets.OceanAurora));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+    }
+
+    [Fact]
+    public void Explicit_Colors_Override_Preset()
+    {
+        var overrideColors = new[] { "#ff0000", "#00ff00" };
+        var cut = Render<WavyBackground>(p => p
+            .Add(x => x.Preset, WavePresets.OceanAurora)
+            .Add(x => x.Colors, overrideColors));
+
+        Assert.Equal(overrideColors, cut.Instance.Colors);
+    }
+
+    [Fact]
+    public void WavePresets_Default_Matches_Component_Defaults()
+    {
+        var preset = WavePresets.Default;
+        Assert.Equal(5, preset.WaveCount);
+        Assert.Equal(50, preset.WaveWidth);
+        Assert.Equal(0.004, preset.Speed);
+        Assert.Equal(0.5, preset.Opacity);
+        Assert.Equal("#0c0c14", preset.BackgroundColor);
+    }
+
+    [Fact]
+    public void WavePresets_All_Have_NonEmpty_Colors()
+    {
+        var presets = new[]
+        {
+            WavePresets.Default,
+            WavePresets.OceanAurora,
+            WavePresets.SunsetFire,
+            WavePresets.NeonCyberpunk,
+            WavePresets.MinimalFrost,
+            WavePresets.NorthernLights,
+            WavePresets.MoltenGold,
+        };
+
+        foreach (var preset in presets)
+        {
+            Assert.NotEmpty(preset.Colors);
+            Assert.All(preset.Colors, c => Assert.NotEmpty(c));
+            Assert.True(preset.WaveCount > 0);
+            Assert.True(preset.Opacity > 0);
+            Assert.True(preset.Speed > 0);
+        }
+    }
+
+    [Fact]
+    public void Custom_Preset_Via_With_Clone()
+    {
+        var custom = WavePresets.OceanAurora with { Speed = 0.01, WaveCount = 10 };
+        Assert.Equal(0.01, custom.Speed);
+        Assert.Equal(10, custom.WaveCount);
+        // Original is unchanged
+        Assert.Equal(0.004, WavePresets.OceanAurora.Speed);
+        Assert.Equal(6, WavePresets.OceanAurora.WaveCount);
+    }
 }


### PR DESCRIPTION
Closes #9

## Summary

Adds a strongly-typed preset system so developers can apply curated color palettes with full IntelliSense support instead of copying arrays.

## Changes

### New: WavePresets.cs
- WavePresetConfig record with all configurable properties
- WavePresets static class with 7 presets: Default, OceanAurora, SunsetFire, NeonCyberpunk, MinimalFrost, NorthernLights, MoltenGold
- Records support with expressions for easy customization

### Modified: WavyBackground.razor.cs
- New Preset parameter accepts a WavePresetConfig
- Individual parameters use nullable backing fields with non-nullable public getters - preserving backward compatibility
- Getter resolution order: explicit override > preset value > Defaults fallback
- Single Defaults instance eliminates duplicated fallback values

### Tests
- 7 new tests: preset null by default, preset colors used with assertion, explicit overrides, defaults match, all presets valid, with clone immutability
- All 21 tests pass

## Bug Fixes
- Backward compatibility: Reverted nullable parameter types back to non-nullable with nullable backing fields. The original nullable types would break existing consumer code with compiler warnings.
- Preset resolution test: Added assertion that Colors getter actually resolves to preset colors when no override is set.