### PR TITLE
feat: add gradient wave fills

### DIFF
--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -3,9 +3,15 @@ using Microsoft.JSInterop;
 
 namespace HeroWave.Components;
 
+/// <summary>
+/// Controls how wave strokes are filled.
+/// </summary>
 public enum GradientMode
 {
+    /// <summary>Waves use a flat solid color.</summary>
     Solid,
+
+    /// <summary>Waves use a vertical linear gradient that fades at the edges.</summary>
     Vertical
 }
 
@@ -74,7 +80,6 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
     /// <summary>
     /// Gradient mode for wave rendering. Defaults to <c>GradientMode.Solid</c>.
-    /// Set to <c>GradientMode.Vertical</c> for an ethereal glow effect.
     /// </summary>
     [Parameter] public GradientMode Gradient { get; set; } = GradientMode.Solid;
 

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -3,6 +3,12 @@ using Microsoft.JSInterop;
 
 namespace HeroWave.Components;
 
+public enum GradientMode
+{
+    Solid,
+    Vertical
+}
+
 public partial class WavyBackground : ComponentBase, IAsyncDisposable
 {
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -66,6 +72,12 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     /// </summary>
     [Parameter] public string? CssClass { get; set; }
 
+    /// <summary>
+    /// Gradient mode for wave rendering. Defaults to <c>GradientMode.Solid</c>.
+    /// Set to <c>GradientMode.Vertical</c> for an ethereal glow effect.
+    /// </summary>
+    [Parameter] public GradientMode Gradient { get; set; } = GradientMode.Solid;
+
     private ElementReference _canvas;
     private IJSObjectReference? _module;
     private string? _instanceId;
@@ -84,7 +96,8 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
             waveCount = WaveCount,
             waveWidth = WaveWidth,
             speed = Speed,
-            opacity = Opacity
+            opacity = Opacity,
+            gradient = Gradient.ToString().ToLowerInvariant()
         };
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -134,7 +134,19 @@ export function init(canvas, config) {
                 else { path.lineTo(x, y); }
             }
 
-            ctx.strokeStyle = colors[i % colors.length];
+            const color = colors[i % colors.length];
+
+            if (config.gradient === 'vertical') {
+                const amplitude = 100 * scale;
+                const yCenter = h * 0.5;
+                const gradient = ctx.createLinearGradient(0, yCenter - amplitude, 0, yCenter + amplitude);
+                gradient.addColorStop(0, color + '00');
+                gradient.addColorStop(0.5, color + 'cc');
+                gradient.addColorStop(1, color + '00');
+                ctx.strokeStyle = gradient;
+            } else {
+                ctx.strokeStyle = color;
+            }
             for (const layer of layers) {
                 ctx.globalAlpha = layer.alpha;
                 ctx.lineWidth = layer.width;

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -16,6 +16,32 @@ function _contrib(g, x, y, z) {
     return t < 0 ? 0 : t * t * t * t * _dot(g, x, y, z);
 }
 
+// Convert any CSS color to "rgba(r, g, b, a)" for gradient color stops.
+// Handles 6-digit hex, 3-digit hex, and falls back to canvas parsing.
+function colorWithAlpha(color, alpha) {
+    // 6-digit hex: #RRGGBB
+    if (/^#[0-9a-f]{6}$/i.test(color)) {
+        const r = parseInt(color.slice(1, 3), 16);
+        const g = parseInt(color.slice(3, 5), 16);
+        const b = parseInt(color.slice(5, 7), 16);
+        return `rgba(${r},${g},${b},${alpha})`;
+    }
+    // 3-digit hex: #RGB
+    if (/^#[0-9a-f]{3}$/i.test(color)) {
+        const r = parseInt(color[1] + color[1], 16);
+        const g = parseInt(color[2] + color[2], 16);
+        const b = parseInt(color[3] + color[3], 16);
+        return `rgba(${r},${g},${b},${alpha})`;
+    }
+    // For named colors, rgb(), hsl(), etc — use canvas to parse
+    const ctx2 = _tmpCtx || (_tmpCtx = document.createElement("canvas").getContext("2d"));
+    ctx2.fillStyle = color;
+    ctx2.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx2.getImageData(0, 0, 1, 1).data;
+    return `rgba(${r},${g},${b},${alpha})`;
+}
+let _tmpCtx = null;
+
 function createNoise() {
     const perm = new Uint8Array(512);
     const p = new Uint8Array(256);
@@ -140,9 +166,9 @@ export function init(canvas, config) {
 
             if (config.gradient === 'vertical') {
                 const gradient = ctx.createLinearGradient(0, yCenter - amplitude, 0, yCenter + amplitude);
-                gradient.addColorStop(0, color + '00');
-                gradient.addColorStop(0.5, color + 'cc');
-                gradient.addColorStop(1, color + '00');
+                gradient.addColorStop(0, colorWithAlpha(color, 0));
+                gradient.addColorStop(0.5, colorWithAlpha(color, 0.8));
+                gradient.addColorStop(1, colorWithAlpha(color, 0));
                 ctx.strokeStyle = gradient;
             } else {
                 ctx.strokeStyle = color;

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -117,6 +117,8 @@ export function init(canvas, config) {
         if (!running) return;
         const w = canvas.width;
         const h = canvas.height;
+        const amplitude = 100 * scale;
+        const yCenter = h * 0.5;
 
         ctx.globalAlpha = 1;
         ctx.fillStyle = config.backgroundColor;
@@ -129,7 +131,7 @@ export function init(canvas, config) {
             let first = true;
             for (let x = 0; x < w; x += step) {
                 const px = x / scale;
-                const y = noise(px / 800, 0.3 * i, nt) * 100 * scale + h * 0.5;
+                const y = noise(px / 800, 0.3 * i, nt) * amplitude + yCenter;
                 if (first) { path.moveTo(x, y); first = false; }
                 else { path.lineTo(x, y); }
             }
@@ -137,8 +139,6 @@ export function init(canvas, config) {
             const color = colors[i % colors.length];
 
             if (config.gradient === 'vertical') {
-                const amplitude = 100 * scale;
-                const yCenter = h * 0.5;
                 const gradient = ctx.createLinearGradient(0, yCenter - amplitude, 0, yCenter + amplitude);
                 gradient.addColorStop(0, color + '00');
                 gradient.addColorStop(0.5, color + 'cc');

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -152,4 +152,28 @@ public class WavyBackgroundTests : BunitContext
         // Should not throw
         await DisposeComponentsAsync();
     }
+
+    [Fact]
+    public void Default_Gradient_Is_Solid()
+    {
+        var cut = Render<WavyBackground>();
+        Assert.Equal(GradientMode.Solid, cut.Instance.Gradient);
+    }
+
+    [Fact]
+    public void Gradient_Parameter_Is_Passed_In_JsInit_Config()
+    {
+        Render<WavyBackground>(p => p.Add(x => x.Gradient, GradientMode.Vertical));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+    }
+
+    [Fact]
+    public void Renders_Without_Error_When_Gradient_Vertical()
+    {
+        var cut = Render<WavyBackground>(p => p.Add(x => x.Gradient, GradientMode.Vertical));
+        var container = cut.Find(".wavy-background-container");
+        Assert.NotNull(container);
+    }
 }


### PR DESCRIPTION
Closes #10

## Summary

Adds optional gradient fills on waves for a softer, more ethereal visual effect. Default behavior (Solid) is unchanged.

## Bug Fixes
- Gradient color stops now use colorWithAlpha() helper instead of string concatenation (color + 00). The old approach only worked for 6-digit hex colors - named colors like red, shorthand hex like #f00, and CSS functions like rgb() all produced invalid CSS and silently rendered as transparent or black.