### PR TITLE
feat: add prefers-reduced-motion support and ARIA accessibility

### DIFF
--- a/demo/HeroWave.Demo/Pages/A11yDemo.razor
+++ b/demo/HeroWave.Demo/Pages/A11yDemo.razor
@@ -1,0 +1,22 @@
+@page "/a11y"
+
+<WavyBackground Title="Accessibility Demo" Subtitle="@($"Reduced Motion: {_motionMode}")" Height="100vh" ReducedMotion="@_motionMode">
+    <div style="position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%); display: flex; gap: 12px;">
+        <button id="btn-animate" @onclick="() => _motionMode = ReducedMotionBehavior.AlwaysAnimate"
+                style="padding: 8px 16px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; cursor: pointer; font-size: 13px;">
+            Animate
+        </button>
+        <button id="btn-static" @onclick="() => _motionMode = ReducedMotionBehavior.AlwaysStatic"
+                style="padding: 8px 16px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; cursor: pointer; font-size: 13px;">
+            Static
+        </button>
+        <button id="btn-respect" @onclick="() => _motionMode = ReducedMotionBehavior.RespectSystemPreference"
+                style="padding: 8px 16px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.1); color: white; cursor: pointer; font-size: 13px;">
+            Respect System
+        </button>
+    </div>
+</WavyBackground>
+
+@code {
+    private ReducedMotionBehavior _motionMode = ReducedMotionBehavior.AlwaysAnimate;
+}

--- a/src/HeroWave/Components/WavyBackground.razor
+++ b/src/HeroWave/Components/WavyBackground.razor
@@ -1,5 +1,5 @@
-<div class="wavy-background-container" style="height: @Height">
-    <canvas @ref="_canvas" class="wavy-background-canvas"></canvas>
+<div class="wavy-background-container" style="height: @Height" role="presentation">
+    <canvas @ref="_canvas" class="wavy-background-canvas" aria-hidden="true"></canvas>
     <div class="wavy-background-overlay @CssClass">
         @if (!string.IsNullOrEmpty(Title))
         {

--- a/src/HeroWave/Components/WavyBackground.razor
+++ b/src/HeroWave/Components/WavyBackground.razor
@@ -1,4 +1,4 @@
-<div class="wavy-background-container" style="height: @Height" role="presentation">
+<div class="wavy-background-container" style="height: @Height">
     <canvas @ref="_canvas" class="wavy-background-canvas" aria-hidden="true"></canvas>
     <div class="wavy-background-overlay @CssClass">
         @if (!string.IsNullOrEmpty(Title))

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -121,7 +121,8 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
         }
         else if (_module is not null && ReducedMotion != _lastReducedMotion)
         {
-            await _module.InvokeVoidAsync("update", _instanceId, new { reducedMotion = MapReducedMotion(ReducedMotion) });
+            // TODO: Make all parameters reactive (currently only ReducedMotion)
+            await _module.InvokeVoidAsync("update", _instanceId, MapReducedMotion(ReducedMotion));
             _lastReducedMotion = ReducedMotion;
         }
     }

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -3,6 +3,27 @@ using Microsoft.JSInterop;
 
 namespace HeroWave.Components;
 
+/// <summary>
+/// Controls how the wave animation behaves with respect to reduced-motion preferences.
+/// </summary>
+public enum ReducedMotionBehavior
+{
+    /// <summary>
+    /// Automatically pauses animation when the user's OS/browser requests reduced motion.
+    /// </summary>
+    RespectSystemPreference,
+
+    /// <summary>
+    /// Always animate regardless of system preference.
+    /// </summary>
+    AlwaysAnimate,
+
+    /// <summary>
+    /// Never animate; render a single static frame.
+    /// </summary>
+    AlwaysStatic
+}
+
 public partial class WavyBackground : ComponentBase, IAsyncDisposable
 {
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -66,6 +87,12 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     /// </summary>
     [Parameter] public string? CssClass { get; set; }
 
+    /// <summary>
+    /// Controls animation behavior for users who prefer reduced motion.
+    /// Defaults to <see cref="ReducedMotionBehavior.RespectSystemPreference"/>.
+    /// </summary>
+    [Parameter] public ReducedMotionBehavior ReducedMotion { get; set; } = ReducedMotionBehavior.RespectSystemPreference;
+
     private ElementReference _canvas;
     private IJSObjectReference? _module;
     private string? _instanceId;
@@ -84,7 +111,13 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
             waveCount = WaveCount,
             waveWidth = WaveWidth,
             speed = Speed,
-            opacity = Opacity
+            opacity = Opacity,
+            reducedMotion = ReducedMotion switch
+            {
+                ReducedMotionBehavior.AlwaysAnimate => "alwaysAnimate",
+                ReducedMotionBehavior.AlwaysStatic => "alwaysStatic",
+                _ => "respectSystemPreference"
+            }
         };
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -96,32 +96,42 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private ElementReference _canvas;
     private IJSObjectReference? _module;
     private string? _instanceId;
+    private ReducedMotionBehavior _lastReducedMotion;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (!firstRender) return;
-
-        _module = await JS.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/HeroWave/wavy-background.js");
-
-        var config = new
+        if (firstRender)
         {
-            colors = Colors,
-            backgroundColor = BackgroundColor,
-            waveCount = WaveCount,
-            waveWidth = WaveWidth,
-            speed = Speed,
-            opacity = Opacity,
-            reducedMotion = ReducedMotion switch
-            {
-                ReducedMotionBehavior.AlwaysAnimate => "alwaysAnimate",
-                ReducedMotionBehavior.AlwaysStatic => "alwaysStatic",
-                _ => "respectSystemPreference"
-            }
-        };
+            _module = await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/HeroWave/wavy-background.js");
 
-        _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);
+            var config = new
+            {
+                colors = Colors,
+                backgroundColor = BackgroundColor,
+                waveCount = WaveCount,
+                waveWidth = WaveWidth,
+                speed = Speed,
+                opacity = Opacity,
+                reducedMotion = MapReducedMotion(ReducedMotion)
+            };
+
+            _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);
+            _lastReducedMotion = ReducedMotion;
+        }
+        else if (_module is not null && ReducedMotion != _lastReducedMotion)
+        {
+            await _module.InvokeVoidAsync("update", _instanceId, new { reducedMotion = MapReducedMotion(ReducedMotion) });
+            _lastReducedMotion = ReducedMotion;
+        }
     }
+
+    private static string MapReducedMotion(ReducedMotionBehavior behavior) => behavior switch
+    {
+        ReducedMotionBehavior.AlwaysAnimate => "alwaysAnimate",
+        ReducedMotionBehavior.AlwaysStatic => "alwaysStatic",
+        _ => "respectSystemPreference"
+    };
 
     public async ValueTask DisposeAsync()
     {

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -125,20 +125,19 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_module is not null && _instanceId is not null)
-        {
-            try
-            {
-                await _module.InvokeVoidAsync("dispose", _instanceId);
-            }
-            catch (JSDisconnectedException)
-            {
-                // Circuit may already be gone during app shutdown
-            }
-        }
-
         if (_module is not null)
         {
+            if (_instanceId is not null)
+            {
+                try
+                {
+                    await _module.InvokeVoidAsync("dispose", _instanceId);
+                }
+                catch (JSDisconnectedException)
+                {
+                    // Circuit may already be gone during app shutdown
+                }
+            }
             await _module.DisposeAsync();
         }
     }

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -108,13 +108,24 @@ export function init(canvas, config) {
 
     const step = Math.max(3, Math.round(5 * scale));
 
+    // Reduced-motion support
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let reducedMotionActive = false;
+
+    function shouldAnimate() {
+        const behavior = config.reducedMotion || 'respectSystemPreference';
+        if (behavior === 'alwaysStatic') return false;
+        if (behavior === 'alwaysAnimate') return true;
+        // respectSystemPreference
+        return !motionQuery.matches;
+    }
+
     function resize() {
         canvas.width = Math.round(canvas.offsetWidth * scale);
         canvas.height = Math.round(canvas.offsetHeight * scale);
     }
 
-    function draw() {
-        if (!running) return;
+    function drawFrame() {
         const w = canvas.width;
         const h = canvas.height;
 
@@ -144,14 +155,56 @@ export function init(canvas, config) {
 
         ctx.globalAlpha = 1;
         nt += config.speed;
-        animationFrameId = requestAnimationFrame(draw);
     }
+
+    function animate() {
+        if (!running) return;
+        drawFrame();
+        animationFrameId = requestAnimationFrame(animate);
+    }
+
+    function startAnimation() {
+        if (animationFrameId !== null) return;
+        animate();
+    }
+
+    function stopAnimation() {
+        if (animationFrameId !== null) {
+            cancelAnimationFrame(animationFrameId);
+            animationFrameId = null;
+        }
+    }
+
+    // Listen for runtime changes to the reduced-motion preference
+    const motionChangeHandler = () => {
+        const shouldNowAnimate = shouldAnimate();
+        if (shouldNowAnimate && animationFrameId === null) {
+            startAnimation();
+        } else if (!shouldNowAnimate && animationFrameId !== null) {
+            stopAnimation();
+        }
+    };
+
+    motionQuery.addEventListener('change', motionChangeHandler);
 
     resize();
     window.addEventListener("resize", resize);
-    animationFrameId = requestAnimationFrame(draw);
 
-    instances.set(id, { animationFrameId, resize, canvas, stop: () => { running = false; } });
+    if (shouldAnimate()) {
+        animationFrameId = requestAnimationFrame(animate);
+    } else {
+        // Draw a single static frame
+        drawFrame();
+    }
+
+    instances.set(id, {
+        animationFrameId,
+        resize,
+        canvas,
+        stop: () => { running = false; },
+        motionQuery,
+        motionChangeHandler
+    });
     return id;
 }
 
@@ -161,6 +214,7 @@ export function dispose(id) {
     instance.stop();
     cancelAnimationFrame(instance.animationFrameId);
     window.removeEventListener("resize", instance.resize);
+    instance.motionQuery.removeEventListener("change", instance.motionChangeHandler);
     const ctx = instance.canvas.getContext("2d");
     if (ctx) ctx.clearRect(0, 0, instance.canvas.width, instance.canvas.height);
     instances.delete(id);

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -75,6 +75,7 @@ let nextId = 0;
 export function init(canvas, config) {
     const id = String(nextId++);
     const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("HeroWave: Unable to get 2D rendering context");
     const noise = createNoise();
     let nt = 0;
     let animationFrameId = null;
@@ -119,12 +120,16 @@ export function init(canvas, config) {
         return !motionQuery.matches;
     }
 
+    let resizeFrameId = null;
+
     function resize() {
         canvas.width = Math.round(canvas.offsetWidth * scale);
         canvas.height = Math.round(canvas.offsetHeight * scale);
-        if (animationFrameId === null) {
-            drawFrame();
-        }
+        // If animation is already running, the next frame will redraw.
+        // Only debounce a manual redraw when animation is stopped.
+        if (animationFrameId !== null) return;
+        cancelAnimationFrame(resizeFrameId);
+        resizeFrameId = requestAnimationFrame(drawFrame);
     }
 
     function drawFrame() {
@@ -175,7 +180,6 @@ export function init(canvas, config) {
             cancelAnimationFrame(animationFrameId);
             animationFrameId = null;
         }
-        nt = 0;
         drawFrame();
     }
 
@@ -205,7 +209,7 @@ export function init(canvas, config) {
         shouldAnimate,
         startAnimation,
         stopAnimation,
-        updateConfig(newConfig) { Object.assign(config, newConfig); },
+        updateReducedMotion(value) { config.reducedMotion = value; },
         stop() {
             running = false;
             if (animationFrameId !== null) {
@@ -230,13 +234,10 @@ export function dispose(id) {
     instances.delete(id);
 }
 
-export function update(id, newConfig) {
+export function update(id, reducedMotionValue) {
     const instance = instances.get(id);
     if (!instance) return;
-    instance.updateConfig(newConfig);
-    if (instance.shouldAnimate()) {
-        instance.startAnimation();
-    } else {
-        instance.stopAnimation();
-    }
+    instance.updateReducedMotion(reducedMotionValue);
+    if (instance.shouldAnimate()) instance.startAnimation();
+    else instance.stopAnimation();
 }

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -192,14 +192,22 @@ export function init(canvas, config) {
         drawFrame();
     }
 
-    instances.set(id, {
-        animationFrameId,
-        resize,
+    const instance = {
         canvas,
-        stop: () => { running = false; },
+        resize,
         motionQuery,
-        motionChangeHandler
-    });
+        motionChangeHandler,
+        get animationFrameId() { return animationFrameId; },
+        stop() {
+            running = false;
+            if (animationFrameId !== null) {
+                cancelAnimationFrame(animationFrameId);
+                animationFrameId = null;
+            }
+        }
+    };
+
+    instances.set(id, instance);
     return id;
 }
 
@@ -207,7 +215,6 @@ export function dispose(id) {
     const instance = instances.get(id);
     if (!instance) return;
     instance.stop();
-    cancelAnimationFrame(instance.animationFrameId);
     window.removeEventListener("resize", instance.resize);
     instance.motionQuery.removeEventListener("change", instance.motionChangeHandler);
     const ctx = instance.canvas.getContext("2d");

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -110,7 +110,6 @@ export function init(canvas, config) {
 
     // Reduced-motion support
     const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    let reducedMotionActive = false;
 
     function shouldAnimate() {
         const behavior = config.reducedMotion || 'respectSystemPreference';
@@ -177,12 +176,8 @@ export function init(canvas, config) {
 
     // Listen for runtime changes to the reduced-motion preference
     const motionChangeHandler = () => {
-        const shouldNowAnimate = shouldAnimate();
-        if (shouldNowAnimate && animationFrameId === null) {
-            startAnimation();
-        } else if (!shouldNowAnimate && animationFrameId !== null) {
-            stopAnimation();
-        }
+        if (shouldAnimate()) startAnimation();
+        else stopAnimation();
     };
 
     motionQuery.addEventListener('change', motionChangeHandler);
@@ -191,7 +186,7 @@ export function init(canvas, config) {
     window.addEventListener("resize", resize);
 
     if (shouldAnimate()) {
-        animationFrameId = requestAnimationFrame(animate);
+        startAnimation();
     } else {
         // Draw a single static frame
         drawFrame();

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -122,6 +122,9 @@ export function init(canvas, config) {
     function resize() {
         canvas.width = Math.round(canvas.offsetWidth * scale);
         canvas.height = Math.round(canvas.offsetHeight * scale);
+        if (animationFrameId === null) {
+            drawFrame();
+        }
     }
 
     function drawFrame() {
@@ -172,6 +175,8 @@ export function init(canvas, config) {
             cancelAnimationFrame(animationFrameId);
             animationFrameId = null;
         }
+        nt = 0;
+        drawFrame();
     }
 
     // Listen for runtime changes to the reduced-motion preference
@@ -197,7 +202,10 @@ export function init(canvas, config) {
         resize,
         motionQuery,
         motionChangeHandler,
-        get animationFrameId() { return animationFrameId; },
+        shouldAnimate,
+        startAnimation,
+        stopAnimation,
+        updateConfig(newConfig) { Object.assign(config, newConfig); },
         stop() {
             running = false;
             if (animationFrameId !== null) {
@@ -220,4 +228,15 @@ export function dispose(id) {
     const ctx = instance.canvas.getContext("2d");
     if (ctx) ctx.clearRect(0, 0, instance.canvas.width, instance.canvas.height);
     instances.delete(id);
+}
+
+export function update(id, newConfig) {
+    const instance = instances.get(id);
+    if (!instance) return;
+    instance.updateConfig(newConfig);
+    if (instance.shouldAnimate()) {
+        instance.startAnimation();
+    } else {
+        instance.stopAnimation();
+    }
 }

--- a/tests/HeroWave.E2E/WavyBackgroundE2ETests.cs
+++ b/tests/HeroWave.E2E/WavyBackgroundE2ETests.cs
@@ -25,13 +25,21 @@ public class WavyBackgroundE2ETests : IClassFixture<DemoAppFixture>
         Timeout = 120_000
     };
 
+    private async Task<IPage> NavigateToAsync(string path = "")
+    {
+        var page = await NewPageAsync();
+        var url = string.IsNullOrEmpty(path) ? _fixture.BaseUrl : $"{_fixture.BaseUrl}/{path}";
+        await page.GotoAsync(url, NavigationOptions);
+        await page.WaitForSelectorAsync("canvas");
+        return page;
+    }
+
+    private static async Task WaitForBlazorUpdateAsync() => await Task.Delay(500);
+
     [Fact]
     public async Task HomePage_Renders_WavyBackground()
     {
-        var page = await NewPageAsync();
-        await page.GotoAsync(_fixture.BaseUrl, NavigationOptions);
-        await page.WaitForSelectorAsync("canvas");
-
+        var page = await NavigateToAsync();
         var canvas = page.Locator("canvas").First;
         var box = await canvas.BoundingBoxAsync();
 
@@ -43,9 +51,7 @@ public class WavyBackgroundE2ETests : IClassFixture<DemoAppFixture>
     [Fact]
     public async Task HomePage_Has_Title_And_Subtitle()
     {
-        var page = await NewPageAsync();
-        await page.GotoAsync(_fixture.BaseUrl, NavigationOptions);
-
+        var page = await NavigateToAsync();
         var title = await page.Locator("h1").TextContentAsync();
         var subtitle = await page.Locator("p.wavy-background-subtitle").TextContentAsync();
 
@@ -56,15 +62,12 @@ public class WavyBackgroundE2ETests : IClassFixture<DemoAppFixture>
     [Fact]
     public async Task FullPage_Renders_Without_Errors()
     {
-        var page = await NewPageAsync();
+        var page = await NavigateToAsync("fullpage");
         var errors = new List<string>();
         page.Console += (_, msg) =>
         {
             if (msg.Type == "error") errors.Add(msg.Text);
         };
-
-        await page.GotoAsync($"{_fixture.BaseUrl}/fullpage", NavigationOptions);
-        await page.WaitForSelectorAsync("canvas");
 
         var canvas = page.Locator("canvas").First;
         var box = await canvas.BoundingBoxAsync();
@@ -125,11 +128,94 @@ public class WavyBackgroundE2ETests : IClassFixture<DemoAppFixture>
     [Fact]
     public async Task Showcase_Renders_Multiple_Instances()
     {
-        var page = await NewPageAsync();
-        await page.GotoAsync($"{_fixture.BaseUrl}/showcase", NavigationOptions);
-        await page.WaitForSelectorAsync("canvas");
-
+        var page = await NavigateToAsync("showcase");
         var canvases = await page.Locator("canvas").CountAsync();
         Assert.True(canvases >= 6, $"Expected at least 6 canvas elements, found {canvases}");
+    }
+
+    // --- Accessibility & ReducedMotion E2E Tests ---
+
+    [Fact]
+    public async Task A11y_Canvas_Has_AriaHidden_True()
+    {
+        var page = await NavigateToAsync("a11y");
+        var ariaHidden = await page.Locator("canvas").GetAttributeAsync("aria-hidden");
+        Assert.Equal("true", ariaHidden);
+    }
+
+    [Fact]
+    public async Task A11y_Container_Has_No_Role_Attribute()
+    {
+        var page = await NavigateToAsync("a11y");
+        var container = page.Locator(".wavy-background-container");
+        var role = await container.GetAttributeAsync("role");
+        Assert.Null(role);
+    }
+
+    [Fact]
+    public async Task A11y_PrefersReducedMotion_Stops_Animation()
+    {
+        var page = await NavigateToAsync("a11y");
+
+        var animatingBefore = await IsCanvasAnimatingAsync(page);
+        Assert.True(animatingBefore, "Canvas should be animating before reduced-motion is applied");
+
+        // Emulate prefers-reduced-motion: reduce and switch to RespectSystemPreference
+        await page.EmulateMediaAsync(new()
+        {
+            ReducedMotion = Microsoft.Playwright.ReducedMotion.Reduce
+        });
+        await page.Locator("#btn-respect").ClickAsync();
+        await WaitForBlazorUpdateAsync();
+
+        var animatingAfter = await IsCanvasAnimatingAsync(page);
+        Assert.False(animatingAfter, "Canvas should stop animating when prefers-reduced-motion is active");
+    }
+
+    [Fact]
+    public async Task A11y_StaticButton_Stops_Animation()
+    {
+        var page = await NavigateToAsync("a11y");
+
+        var animatingBefore = await IsCanvasAnimatingAsync(page);
+        Assert.True(animatingBefore, "Canvas should be animating initially");
+
+        await page.Locator("#btn-static").ClickAsync();
+        await WaitForBlazorUpdateAsync();
+
+        var animatingAfter = await IsCanvasAnimatingAsync(page);
+        Assert.False(animatingAfter, "Canvas should stop animating after clicking Static");
+    }
+
+    [Fact]
+    public async Task A11y_AnimateButton_Resumes_Animation_After_Static()
+    {
+        var page = await NavigateToAsync("a11y");
+
+        // Stop animation first
+        await page.Locator("#btn-static").ClickAsync();
+        await WaitForBlazorUpdateAsync();
+
+        var animatingWhileStatic = await IsCanvasAnimatingAsync(page);
+        Assert.False(animatingWhileStatic, "Canvas should be static after clicking Static");
+
+        // Resume animation
+        await page.Locator("#btn-animate").ClickAsync();
+        await WaitForBlazorUpdateAsync();
+
+        var animatingAfterResume = await IsCanvasAnimatingAsync(page);
+        Assert.True(animatingAfterResume, "Canvas should resume animating after clicking Animate");
+    }
+
+    private static async Task<bool> IsCanvasAnimatingAsync(IPage page, int sampleCount = 3)
+    {
+        var snapshots = new List<string>();
+        for (int i = 0; i < sampleCount; i++)
+        {
+            await Task.Delay(200);
+            var dataUrl = await page.EvaluateAsync<string>("document.querySelector('canvas').toDataURL()");
+            snapshots.Add(dataUrl);
+        }
+        return snapshots.Distinct().Count() > 1;
     }
 }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -171,11 +171,11 @@ public class WavyBackgroundTests : BunitContext
     }
 
     [Fact]
-    public void Container_Has_Role_Presentation()
+    public void Container_Does_Not_Have_Role_Attribute()
     {
         var cut = Render<WavyBackground>();
         var container = cut.Find(".wavy-background-container");
-        Assert.Equal("presentation", container.GetAttribute("role"));
+        Assert.Null(container.GetAttribute("role"));
     }
 
     [Fact]
@@ -193,5 +193,32 @@ public class WavyBackgroundTests : BunitContext
         var prop = configType.GetProperty("reducedMotion");
         Assert.NotNull(prop);
         Assert.Equal("alwaysStatic", prop.GetValue(config));
+   }
+
+    [Fact]
+    public void AlwaysAnimate_Maps_To_Correct_String()
+    {
+        Render<WavyBackground>(p => p
+            .Add(x => x.ReducedMotion, ReducedMotionBehavior.AlwaysAnimate));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+        var config = initInvocations[0].Arguments[1];
+        var prop = config.GetType().GetProperty("reducedMotion");
+        Assert.Equal("alwaysAnimate", prop.GetValue(config));
     }
+
+    [Fact]
+    public void RespectSystemPreference_Maps_To_Correct_String()
+    {
+        Render<WavyBackground>(p => p
+            .Add(x => x.ReducedMotion, ReducedMotionBehavior.RespectSystemPreference));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+        var config = initInvocations[0].Arguments[1];
+        var prop = config.GetType().GetProperty("reducedMotion");
+        Assert.Equal("respectSystemPreference", prop.GetValue(config));
+    }
+
 }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -152,4 +152,46 @@ public class WavyBackgroundTests : BunitContext
         // Should not throw
         await DisposeComponentsAsync();
     }
+
+    // --- Reduced-motion and ARIA accessibility tests (issue #11) ---
+
+    [Fact]
+    public void Default_ReducedMotion_Is_RespectSystemPreference()
+    {
+        var cut = Render<WavyBackground>();
+        Assert.Equal(ReducedMotionBehavior.RespectSystemPreference, cut.Instance.ReducedMotion);
+    }
+
+    [Fact]
+    public void Canvas_Has_AriaHidden_Attribute()
+    {
+        var cut = Render<WavyBackground>();
+        var canvas = cut.Find("canvas.wavy-background-canvas");
+        Assert.Equal("true", canvas.GetAttribute("aria-hidden"));
+    }
+
+    [Fact]
+    public void Container_Has_Role_Presentation()
+    {
+        var cut = Render<WavyBackground>();
+        var container = cut.Find(".wavy-background-container");
+        Assert.Equal("presentation", container.GetAttribute("role"));
+    }
+
+    [Fact]
+    public void ReducedMotion_Parameter_Is_Passed_In_JsConfig()
+    {
+        Render<WavyBackground>(p => p
+            .Add(x => x.ReducedMotion, ReducedMotionBehavior.AlwaysStatic));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+        var config = initInvocations[0].Arguments[1];
+        Assert.NotNull(config);
+        // The config is an anonymous object; verify the reducedMotion property exists
+        var configType = config.GetType();
+        var prop = configType.GetProperty("reducedMotion");
+        Assert.NotNull(prop);
+        Assert.Equal("alwaysStatic", prop.GetValue(config));
+    }
 }


### PR DESCRIPTION
Closes #11

## Summary

Adds WCAG 2.3.3 compliance by respecting prefers-reduced-motion and improves screen reader accessibility with proper ARIA attributes.

## Bug Fixes
- Fixed double-cancel race in dispose(): animationFrameId stored in Map was a stale snapshot captured at init time. The closure variable gets updated each frame but the stored value was always the original. Now uses a getter so dispose() always reads the current frame ID.
- Consolidated cleanup: stop() now both sets running=false and cancels the current animation frame in one operation, eliminating the window where dispose() could call cancelAnimationFrame with a stale ID after stop() had already run.