### PR TITLE
feat: add IntersectionObserver pause, FPS throttling, and debounced resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bld/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TargetFps` parameter (default 60, clamped 1–120) to cap animation frame rate and reduce CPU/GPU usage on less capable devices
+- `IntersectionObserver` to automatically pause the animation loop when the canvas scrolls out of view
+- Debounced window resize handling (100 ms) to avoid layout thrashing
+- Live `update()` JS function so visual parameters can change at runtime without re-initialising the canvas
+- Config hash tracking in `OnParametersSetAsync` to avoid redundant JS interop calls on every re-render
+- Config key allowlist in JS `update()` to prevent arbitrary property injection
 - XML documentation comments on all component parameters for IntelliSense support
 - CHANGELOG.md tracking full release history
 
 ### Fixed
+- `dispose()` crash at runtime: instance stored in `Map` was missing `animationFrameId`, `running`, and `stop()`. Fixed by storing an instance object with getter/bridge methods that access closure variables inside `init()`
+- `update()` silently ignoring `waveWidth`/`opacity` changes: `rebuildLayers()` is now bridged through the instance object so config changes take effect
+- `OnParametersSetAsync` firing on every render: added config hash tracking so JS `update()` is only called when parameter values actually change
+- `frameInterval` stale after `update()`: `targetFps` changes via `update()` now take effect immediately since `frameInterval` is computed per-frame from `cfg.targetFps`
 - Empty `Colors` array no longer crashes rendering (falls back to default palette)
 - Stale blur reference and old repo URL in NuGet readiness spec
 - E2E resize test now uses polling instead of flaky `Task.Delay`
 
 ### Changed
+- `dispose()` now explicitly sets `running = false` via instance `stop()` bridge before cleanup
 - Trimmed unused template imports from demo `_Imports.razor` and unused CSS from `app.css`
 
 ## [2.1.1] - 2026-03-21

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Add the namespace to your `_Imports.razor`:
 | `WaveWidth` | `int` | `50` | Stroke width of each wave (px) |
 | `Speed` | `double` | `0.004` | Animation speed — time increment per frame (e.g. `0.004` slow, `0.008` fast) |
 | `Opacity` | `double` | `0.5` | Wave opacity (0.0 - 1.0) |
+| `TargetFps` | `int` | `60` | Target frames per second. Clamped to 1–120. Lower values reduce CPU/GPU usage. |
 | `CssClass` | `string?` | null | Additional CSS class on the overlay |
+
+> **Live update:** All visual parameters (`Colors`, `BackgroundColor`, `WaveCount`, `WaveWidth`, `Speed`, `Opacity`, `TargetFps`) can be changed at runtime without re-initialising the canvas. The component detects changes via a config hash and only calls the JS `update()` function when values actually change.
 
 ## Examples
 
@@ -117,6 +120,17 @@ Add the namespace to your `_Imports.razor`:
 <WavyBackground Colors="@(new[] { "#fbbf24", "#f59e0b", "#d97706", "#b45309", "#fcd34d" })"
                 BackgroundColor="#1c1208" Speed="0.008" Opacity="0.45" />
 ```
+
+## Performance
+
+HeroWave includes several built-in optimisations:
+
+| Feature | Description |
+|---------|-------------|
+| **FPS Throttling** | `TargetFps` parameter caps frame rate (default 60). Set lower to save CPU/GPU on less capable devices. |
+| **Offscreen Pause** | `IntersectionObserver` pauses the animation loop when the canvas scrolls out of view. |
+| **Debounced Resize** | Window resize events are debounced (100 ms) to avoid layout thrashing. |
+| **Live Update** | Changing parameters at runtime calls `update()` instead of destroying and re-creating the canvas instance. |
 
 ## Contributing
 

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -64,6 +64,7 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     /// <summary>
     /// Target frames per second for the animation loop. Defaults to <c>60</c>.
     /// Lower values reduce CPU/GPU usage on less capable devices.
+    /// Clamped to the range 1–120.
     /// </summary>
     [Parameter] public int TargetFps { get; set; } = 60;
 
@@ -114,6 +115,13 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
 
     protected override async Task OnParametersSetAsync()
     {
+        // OnParametersSetAsync fires BEFORE OnAfterRenderAsync on first render,
+        // so _module/_instanceId will be null during initialisation.
+        // The guard ensures we only call update() on subsequent parameter changes.
+
+        // Clamp TargetFps to valid range
+        TargetFps = Math.Max(1, Math.Min(TargetFps, 120));
+
         if (_module is null || _instanceId is null) return;
 
         var currentHash = ComputeConfigHash();

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -76,6 +76,17 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private IJSObjectReference? _module;
     private string? _instanceId;
 
+    private object BuildConfig() => new
+    {
+        colors = Colors,
+        backgroundColor = BackgroundColor,
+        waveCount = WaveCount,
+        waveWidth = WaveWidth,
+        speed = Speed,
+        opacity = Opacity,
+        targetFps = TargetFps
+    };
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
@@ -83,43 +94,18 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
         _module = await JS.InvokeAsync<IJSObjectReference>(
             "import", "./_content/HeroWave/wavy-background.js");
 
-        var config = new
-        {
-            colors = Colors,
-            backgroundColor = BackgroundColor,
-            waveCount = WaveCount,
-            waveWidth = WaveWidth,
-            speed = Speed,
-            opacity = Opacity,
-            targetFps = TargetFps
-        };
-
-        _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);
+        _instanceId = await _module.InvokeAsync<string>("init", _canvas, BuildConfig());
     }
 
     protected override async Task OnParametersSetAsync()
     {
         if (_module is null || _instanceId is null) return;
 
-        var newConfig = new
-        {
-            colors = Colors,
-            backgroundColor = BackgroundColor,
-            waveCount = WaveCount,
-            waveWidth = WaveWidth,
-            speed = Speed,
-            opacity = Opacity,
-            targetFps = TargetFps
-        };
-
         try
         {
-            await _module.InvokeVoidAsync("update", _instanceId, newConfig);
+            await _module.InvokeVoidAsync("update", _instanceId, BuildConfig());
         }
-        catch (JSDisconnectedException)
-        {
-            // Circuit may already be gone
-        }
+        catch (JSDisconnectedException) { }
     }
 
     public async ValueTask DisposeAsync()
@@ -130,10 +116,7 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
             {
                 await _module.InvokeVoidAsync("dispose", _instanceId);
             }
-            catch (JSDisconnectedException)
-            {
-                // Circuit may already be gone during app shutdown
-            }
+            catch (JSDisconnectedException) { }
         }
 
         if (_module is not null)

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -75,6 +75,7 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private ElementReference _canvas;
     private IJSObjectReference? _module;
     private string? _instanceId;
+    private string? _previousConfigHash;
 
     private object BuildConfig() => new
     {
@@ -87,6 +88,19 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
         targetFps = TargetFps
     };
 
+    private string ComputeConfigHash()
+    {
+        var hash = new HashCode();
+        foreach (var c in Colors) hash.Add(c);
+        hash.Add(BackgroundColor);
+        hash.Add(WaveCount);
+        hash.Add(WaveWidth);
+        hash.Add(Speed);
+        hash.Add(Opacity);
+        hash.Add(TargetFps);
+        return hash.ToHashCode().ToString();
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
@@ -95,11 +109,16 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
             "import", "./_content/HeroWave/wavy-background.js");
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, BuildConfig());
+        _previousConfigHash = ComputeConfigHash();
     }
 
     protected override async Task OnParametersSetAsync()
     {
         if (_module is null || _instanceId is null) return;
+
+        var currentHash = ComputeConfigHash();
+        if (currentHash == _previousConfigHash) return;
+        _previousConfigHash = currentHash;
 
         try
         {

--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -62,6 +62,12 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     [Parameter] public double Opacity { get; set; } = 0.5;
 
     /// <summary>
+    /// Target frames per second for the animation loop. Defaults to <c>60</c>.
+    /// Lower values reduce CPU/GPU usage on less capable devices.
+    /// </summary>
+    [Parameter] public int TargetFps { get; set; } = 60;
+
+    /// <summary>
     /// Optional CSS class applied to the text overlay container.
     /// </summary>
     [Parameter] public string? CssClass { get; set; }
@@ -84,10 +90,36 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
             waveCount = WaveCount,
             waveWidth = WaveWidth,
             speed = Speed,
-            opacity = Opacity
+            opacity = Opacity,
+            targetFps = TargetFps
         };
 
         _instanceId = await _module.InvokeAsync<string>("init", _canvas, config);
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (_module is null || _instanceId is null) return;
+
+        var newConfig = new
+        {
+            colors = Colors,
+            backgroundColor = BackgroundColor,
+            waveCount = WaveCount,
+            waveWidth = WaveWidth,
+            speed = Speed,
+            opacity = Opacity,
+            targetFps = TargetFps
+        };
+
+        try
+        {
+            await _module.InvokeVoidAsync("update", _instanceId, newConfig);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit may already be gone
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -100,7 +100,7 @@ export function init(canvas, config) {
         backgroundColor: config.backgroundColor,
         waveCount: config.waveCount,
         speed: config.speed,
-        targetFps: config.targetFps || 60
+        targetFps: Math.max(1, config.targetFps || 60)
     };
 
     // FPS throttling state
@@ -216,6 +216,8 @@ export function init(canvas, config) {
         config: cfg,
         observer,
         debouncedResize,
+        rebuildLayers: () => { layers = rebuildLayers(); },
+        stop: () => { running = false; },
         get animationFrameId() { return animationFrameId; },
     };
 
@@ -228,17 +230,20 @@ export function update(id, newConfig) {
     if (!instance) return;
 
     const cfg = instance.config;
+    const allowedKeys = ['waveWidth', 'opacity', 'colors', 'backgroundColor', 'waveCount', 'speed', 'targetFps'];
     for (const [key, val] of Object.entries(newConfig)) {
-        if (val !== undefined) cfg[key] = val;
+        if (allowedKeys.includes(key) && val !== undefined) cfg[key] = val;
     }
     if ('waveWidth' in newConfig || 'opacity' in newConfig) {
-        layers = rebuildLayers();
+        instance.rebuildLayers();
     }
 }
 
 export function dispose(id) {
     const instance = instances.get(id);
     if (!instance) return;
+
+    instance.stop();
 
     if (instance.animationFrameId) {
         cancelAnimationFrame(instance.animationFrameId);

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -104,10 +104,7 @@ export function init(canvas, config) {
     };
 
     // FPS throttling state
-    const frameInterval = 1000 / cfg.targetFps;
     let lastFrameTime = 0;
-
-    const opacityScale = cfg.opacity / 0.5;
 
     const layerDefs = [
         { widthMul: 2.4, baseAlpha: 0.02 },
@@ -143,6 +140,7 @@ export function init(canvas, config) {
         if (!running) return;
 
         // FPS throttling: skip frame if not enough time has elapsed
+        const frameInterval = 1000 / cfg.targetFps;
         if (timestamp - lastFrameTime < frameInterval) {
             animationFrameId = requestAnimationFrame(draw);
             return;

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -217,10 +217,6 @@ export function init(canvas, config) {
         observer,
         debouncedResize,
         get animationFrameId() { return animationFrameId; },
-        set animationFrameId(value) { animationFrameId = value; },
-        get running() { return running; },
-        set running(value) { running = value; },
-        stop() { running = false; }
     };
 
     instances.set(id, instance);
@@ -232,17 +228,10 @@ export function update(id, newConfig) {
     if (!instance) return;
 
     const cfg = instance.config;
-    let needsLayerRebuild = false;
-
-    if (newConfig.colors !== undefined) cfg.colors = newConfig.colors;
-    if (newConfig.backgroundColor !== undefined) cfg.backgroundColor = newConfig.backgroundColor;
-    if (newConfig.waveCount !== undefined) cfg.waveCount = newConfig.waveCount;
-    if (newConfig.waveWidth !== undefined) { cfg.waveWidth = newConfig.waveWidth; needsLayerRebuild = true; }
-    if (newConfig.speed !== undefined) cfg.speed = newConfig.speed;
-    if (newConfig.opacity !== undefined) { cfg.opacity = newConfig.opacity; needsLayerRebuild = true; }
-    if (newConfig.targetFps !== undefined) cfg.targetFps = newConfig.targetFps;
-
-    if (needsLayerRebuild) {
+    for (const [key, val] of Object.entries(newConfig)) {
+        if (val !== undefined) cfg[key] = val;
+    }
+    if ('waveWidth' in newConfig || 'opacity' in newConfig) {
         layers = rebuildLayers();
     }
 }
@@ -251,23 +240,14 @@ export function dispose(id) {
     const instance = instances.get(id);
     if (!instance) return;
 
-    // Stop animation
     if (instance.animationFrameId) {
         cancelAnimationFrame(instance.animationFrameId);
     }
 
-    // Disconnect intersection observer
-    if (instance.observer) {
-        instance.observer.disconnect();
-    }
+    instance.observer.disconnect();
+    instance.debouncedResize._clear();
+    window.removeEventListener("resize", instance.debouncedResize);
 
-    // Remove debounced resize listener
-    if (instance.debouncedResize) {
-        instance.debouncedResize._clear();
-        window.removeEventListener("resize", instance.debouncedResize);
-    }
-
-    // Clear canvas
     const ctx = instance.canvas.getContext("2d");
     if (ctx) ctx.clearRect(0, 0, instance.canvas.width, instance.canvas.height);
 

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -72,6 +72,16 @@ function createNoise() {
 const instances = new Map();
 let nextId = 0;
 
+function debounce(fn, ms) {
+    let timer = null;
+    const debounced = function (...args) {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => { timer = null; fn.apply(this, args); }, ms);
+    };
+    debounced._clear = () => { if (timer) { clearTimeout(timer); timer = null; } };
+    return debounced;
+}
+
 export function init(canvas, config) {
     const id = String(nextId++);
     const ctx = canvas.getContext("2d");
@@ -82,11 +92,22 @@ export function init(canvas, config) {
 
     const scale = 0.25;
 
-    const baseW = config.waveWidth;
-    const opacityScale = config.opacity / 0.5;
+    // Mutable config — can be updated via update()
+    const cfg = {
+        waveWidth: config.waveWidth,
+        opacity: config.opacity,
+        colors: config.colors?.length ? config.colors : ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"],
+        backgroundColor: config.backgroundColor,
+        waveCount: config.waveCount,
+        speed: config.speed,
+        targetFps: config.targetFps || 60
+    };
 
-    // Guard against empty colors array
-    const colors = config.colors?.length ? config.colors : ["#38bdf8", "#818cf8", "#c084fc", "#e879f9", "#22d3ee"];
+    // FPS throttling state
+    const frameInterval = 1000 / cfg.targetFps;
+    let lastFrameTime = 0;
+
+    const opacityScale = cfg.opacity / 0.5;
 
     const layerDefs = [
         { widthMul: 2.4, baseAlpha: 0.02 },
@@ -101,10 +122,15 @@ export function init(canvas, config) {
         { widthMul: 0.6, baseAlpha: 0.14 },
     ];
 
-    const layers = layerDefs.map(l => ({
-        width: baseW * l.widthMul * scale,
-        alpha: Math.min(1, l.baseAlpha * opacityScale),
-    }));
+    let layers = rebuildLayers();
+
+    function rebuildLayers() {
+        const opacityScale = cfg.opacity / 0.5;
+        return layerDefs.map(l => ({
+            width: cfg.waveWidth * l.widthMul * scale,
+            alpha: Math.min(1, l.baseAlpha * opacityScale),
+        }));
+    }
 
     const step = Math.max(3, Math.round(5 * scale));
 
@@ -113,18 +139,26 @@ export function init(canvas, config) {
         canvas.height = Math.round(canvas.offsetHeight * scale);
     }
 
-    function draw() {
+    function draw(timestamp) {
         if (!running) return;
+
+        // FPS throttling: skip frame if not enough time has elapsed
+        if (timestamp - lastFrameTime < frameInterval) {
+            animationFrameId = requestAnimationFrame(draw);
+            return;
+        }
+        lastFrameTime = timestamp;
+
         const w = canvas.width;
         const h = canvas.height;
 
         ctx.globalAlpha = 1;
-        ctx.fillStyle = config.backgroundColor;
+        ctx.fillStyle = cfg.backgroundColor;
         ctx.fillRect(0, 0, w, h);
         ctx.lineCap = 'round';
         ctx.lineJoin = 'round';
 
-        for (let i = 0; i < config.waveCount; i++) {
+        for (let i = 0; i < cfg.waveCount; i++) {
             const path = new Path2D();
             let first = true;
             for (let x = 0; x < w; x += step) {
@@ -134,7 +168,7 @@ export function init(canvas, config) {
                 else { path.lineTo(x, y); }
             }
 
-            ctx.strokeStyle = colors[i % colors.length];
+            ctx.strokeStyle = cfg.colors[i % cfg.colors.length];
             for (const layer of layers) {
                 ctx.globalAlpha = layer.alpha;
                 ctx.lineWidth = layer.width;
@@ -143,25 +177,89 @@ export function init(canvas, config) {
         }
 
         ctx.globalAlpha = 1;
-        nt += config.speed;
+        nt += cfg.speed;
         animationFrameId = requestAnimationFrame(draw);
     }
 
-    resize();
-    window.addEventListener("resize", resize);
-    animationFrameId = requestAnimationFrame(draw);
+    function startLoop() {
+        lastFrameTime = 0;
+        animationFrameId = requestAnimationFrame(draw);
+    }
 
-    instances.set(id, { animationFrameId, resize, canvas, stop: () => { running = false; } });
+    // Debounced resize (100ms)
+    const debouncedResize = debounce(resize, 100);
+
+    // IntersectionObserver: pause when not visible
+    const observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+            if (!entry.isIntersecting) {
+                running = false;
+                if (animationFrameId) {
+                    cancelAnimationFrame(animationFrameId);
+                    animationFrameId = null;
+                }
+            } else {
+                running = true;
+                if (!animationFrameId) {
+                    startLoop();
+                }
+            }
+        }
+    }, { threshold: 0 });
+
+    observer.observe(canvas);
+
+    resize();
+    window.addEventListener("resize", debouncedResize);
+    startLoop();
+
+    instances.set(id, {
+        canvas,
+        config: cfg,
+        observer,
+        debouncedResize,
+        rebuildLayers
+    });
     return id;
+}
+
+export function update(id, newConfig) {
+    const instance = instances.get(id);
+    if (!instance) return;
+
+    const cfg = instance.config;
+    if (newConfig.colors !== undefined) cfg.colors = newConfig.colors;
+    if (newConfig.backgroundColor !== undefined) cfg.backgroundColor = newConfig.backgroundColor;
+    if (newConfig.waveCount !== undefined) cfg.waveCount = newConfig.waveCount;
+    if (newConfig.waveWidth !== undefined) cfg.waveWidth = newConfig.waveWidth;
+    if (newConfig.speed !== undefined) cfg.speed = newConfig.speed;
+    if (newConfig.opacity !== undefined) cfg.opacity = newConfig.opacity;
+    if (newConfig.targetFps !== undefined) cfg.targetFps = newConfig.targetFps;
 }
 
 export function dispose(id) {
     const instance = instances.get(id);
     if (!instance) return;
-    instance.stop();
-    cancelAnimationFrame(instance.animationFrameId);
-    window.removeEventListener("resize", instance.resize);
+
+    // Stop animation
+    if (instance.animationFrameId) {
+        cancelAnimationFrame(instance.animationFrameId);
+    }
+
+    // Disconnect intersection observer
+    if (instance.observer) {
+        instance.observer.disconnect();
+    }
+
+    // Remove debounced resize listener
+    if (instance.debouncedResize) {
+        instance.debouncedResize._clear();
+        window.removeEventListener("resize", instance.debouncedResize);
+    }
+
+    // Clear canvas
     const ctx = instance.canvas.getContext("2d");
     if (ctx) ctx.clearRect(0, 0, instance.canvas.width, instance.canvas.height);
+
     instances.delete(id);
 }

--- a/src/HeroWave/wwwroot/wavy-background.js
+++ b/src/HeroWave/wwwroot/wavy-background.js
@@ -211,13 +211,19 @@ export function init(canvas, config) {
     window.addEventListener("resize", debouncedResize);
     startLoop();
 
-    instances.set(id, {
+    const instance = {
         canvas,
         config: cfg,
         observer,
         debouncedResize,
-        rebuildLayers
-    });
+        get animationFrameId() { return animationFrameId; },
+        set animationFrameId(value) { animationFrameId = value; },
+        get running() { return running; },
+        set running(value) { running = value; },
+        stop() { running = false; }
+    };
+
+    instances.set(id, instance);
     return id;
 }
 
@@ -226,13 +232,19 @@ export function update(id, newConfig) {
     if (!instance) return;
 
     const cfg = instance.config;
+    let needsLayerRebuild = false;
+
     if (newConfig.colors !== undefined) cfg.colors = newConfig.colors;
     if (newConfig.backgroundColor !== undefined) cfg.backgroundColor = newConfig.backgroundColor;
     if (newConfig.waveCount !== undefined) cfg.waveCount = newConfig.waveCount;
-    if (newConfig.waveWidth !== undefined) cfg.waveWidth = newConfig.waveWidth;
+    if (newConfig.waveWidth !== undefined) { cfg.waveWidth = newConfig.waveWidth; needsLayerRebuild = true; }
     if (newConfig.speed !== undefined) cfg.speed = newConfig.speed;
-    if (newConfig.opacity !== undefined) cfg.opacity = newConfig.opacity;
+    if (newConfig.opacity !== undefined) { cfg.opacity = newConfig.opacity; needsLayerRebuild = true; }
     if (newConfig.targetFps !== undefined) cfg.targetFps = newConfig.targetFps;
+
+    if (needsLayerRebuild) {
+        layers = rebuildLayers();
+    }
 }
 
 export function dispose(id) {

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -1,6 +1,8 @@
 using Bunit;
 using Bunit.JSInterop;
 using HeroWave.Components;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
 using Xunit;
 
@@ -175,5 +177,97 @@ public class WavyBackgroundTests : BunitContext
         var targetFpsProp = configType.GetProperty("targetFps");
         Assert.NotNull(targetFpsProp);
         Assert.Equal(30, targetFpsProp!.GetValue(initInvocations[0].Arguments[1]));
+    }
+
+    [Fact]
+    public void TargetFps_Is_Clamped_To_Minimum_1()
+    {
+        var cut = Render<WavyBackground>(p => p.Add(x => x.TargetFps, 0));
+        Assert.Equal(1, cut.Instance.TargetFps);
+    }
+
+    [Fact]
+    public void TargetFps_Is_Clamped_To_Maximum_120()
+    {
+        var cut = Render<WavyBackground>(p => p.Add(x => x.TargetFps, 999));
+        Assert.Equal(120, cut.Instance.TargetFps);
+    }
+
+    [Fact]
+    public void TargetFps_Negative_Is_Clamped_To_1()
+    {
+        var cut = Render<WavyBackground>(p => p.Add(x => x.TargetFps, -10));
+        Assert.Equal(1, cut.Instance.TargetFps);
+    }
+
+    /// <summary>
+    /// Host component that renders WavyBackground and allows re-rendering
+    /// with different parameters via StateHasChanged().
+    /// Required because bunit v2's BunitContext.Render&lt;T&gt;() creates new instances
+    /// each call, preventing OnParametersSetAsync testing on initialised components.
+    /// </summary>
+    private class WavyBackgroundHost : ComponentBase
+    {
+        internal double Speed { get; private set; } = 0.004;
+        internal string? Title { get; private set; }
+
+        public void ChangeSpeed(double speed) { Speed = speed; StateHasChanged(); }
+        public void ChangeTitle(string? title) { Title = title; StateHasChanged(); }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<WavyBackground>(0);
+            builder.AddComponentParameter(1, nameof(WavyBackground.Speed), Speed);
+            if (Title is not null)
+                builder.AddComponentParameter(2, nameof(WavyBackground.Title), Title);
+            builder.CloseComponent();
+        }
+    }
+
+    [Fact]
+    public void OnParametersSetAsync_CallsUpdate_WhenConfigChanges()
+    {
+        // Render host which renders WavyBackground internally
+        var host = Render<WavyBackgroundHost>();
+
+        // Trigger re-render of the same WavyBackground instance with changed Speed
+        host.InvokeAsync(() => host.Instance.ChangeSpeed(0.01));
+
+        // update() should have been called because Speed changed
+        var updateInvocations = _moduleInterop.Invocations["update"];
+        Assert.Single(updateInvocations);
+    }
+
+    [Fact]
+    public void OnParametersSetAsync_SkipsUpdate_WhenConfigUnchanged()
+    {
+        // Render host which renders WavyBackground internally
+        var host = Render<WavyBackgroundHost>();
+
+        // Trigger re-render with a non-config parameter change (Title)
+        host.InvokeAsync(() => host.Instance.ChangeTitle("New Title"));
+
+        // update() should NOT have been called since config values didn't change
+        var updateInvocations = _moduleInterop.Invocations["update"];
+        Assert.Empty(updateInvocations);
+    }
+
+    [Fact]
+    public async Task OnParametersSetAsync_Handles_JSDisconnectedException()
+    {
+        JSInterop.Mode = JSRuntimeMode.Strict;
+        var strictModule = JSInterop.SetupModule("./_content/HeroWave/wavy-background.js");
+        strictModule.Setup<string>("init", _ => true).SetResult("test-instance-update-err");
+        strictModule.SetupVoid("update", _ => true)
+            .SetException(new JSDisconnectedException("Circuit disconnected"));
+
+        // Render host which renders WavyBackground internally
+        var host = Render<WavyBackgroundHost>();
+
+        // Trigger re-render with changed config — update() throws JSDisconnectedException
+        // which should be caught silently
+        await host.InvokeAsync(() => host.Instance.ChangeSpeed(0.01));
+
+        await DisposeComponentsAsync();
     }
 }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -169,24 +169,11 @@ public class WavyBackgroundTests : BunitContext
 
         var initInvocations = _moduleInterop.Invocations["init"];
         Assert.Single(initInvocations);
-
-        // The config is passed as the second argument to init (canvas, config)
         Assert.Equal(2, initInvocations[0].Arguments.Count);
-        Assert.NotNull(initInvocations[0].Arguments[1]);
 
-        // Verify the anonymous config type has the targetFps property
         var configType = initInvocations[0].Arguments[1]!.GetType();
         var targetFpsProp = configType.GetProperty("targetFps");
         Assert.NotNull(targetFpsProp);
         Assert.Equal(30, targetFpsProp!.GetValue(initInvocations[0].Arguments[1]));
-    }
-
-    [Fact]
-    public void Component_Renders_Without_Error()
-    {
-        var cut = Render<WavyBackground>();
-        Assert.NotNull(cut);
-        Assert.Single(cut.FindAll(".wavy-background-container"));
-        Assert.Single(cut.FindAll("canvas.wavy-background-canvas"));
     }
 }

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -16,6 +16,7 @@ public class WavyBackgroundTests : BunitContext
         _moduleInterop = JSInterop.SetupModule("./_content/HeroWave/wavy-background.js");
         _moduleInterop.Setup<string>("init", _ => true).SetResult("test-instance-0");
         _moduleInterop.SetupVoid("dispose", _ => true);
+        _moduleInterop.SetupVoid("update", _ => true);
     }
 
     [Fact]
@@ -151,5 +152,41 @@ public class WavyBackgroundTests : BunitContext
 
         // Should not throw
         await DisposeComponentsAsync();
+    }
+
+    [Fact]
+    public void Default_TargetFps_Is_60()
+    {
+        var cut = Render<WavyBackground>();
+        var component = cut.Instance;
+        Assert.Equal(60, component.TargetFps);
+    }
+
+    [Fact]
+    public void TargetFps_Is_Passed_In_JsConfig()
+    {
+        Render<WavyBackground>(p => p.Add(x => x.TargetFps, 30));
+
+        var initInvocations = _moduleInterop.Invocations["init"];
+        Assert.Single(initInvocations);
+
+        // The config is passed as the second argument to init (canvas, config)
+        Assert.Equal(2, initInvocations[0].Arguments.Count);
+        Assert.NotNull(initInvocations[0].Arguments[1]);
+
+        // Verify the anonymous config type has the targetFps property
+        var configType = initInvocations[0].Arguments[1]!.GetType();
+        var targetFpsProp = configType.GetProperty("targetFps");
+        Assert.NotNull(targetFpsProp);
+        Assert.Equal(30, targetFpsProp!.GetValue(initInvocations[0].Arguments[1]));
+    }
+
+    [Fact]
+    public void Component_Renders_Without_Error()
+    {
+        var cut = Render<WavyBackground>();
+        Assert.NotNull(cut);
+        Assert.Single(cut.FindAll(".wavy-background-container"));
+        Assert.Single(cut.FindAll("canvas.wavy-background-canvas"));
     }
 }


### PR DESCRIPTION
Closes #12

## Summary

Three performance optimizations: pause rendering when offscreen, cap frame rate, and debounce resize events. Also adds a live `update()` JS function for parameter changes without re-initialization.

## Performance Features

| Feature | Description |
|---------|-------------|
| FPS Throttling | `TargetFps` parameter caps frame rate (default 60, clamped 1–120). Set lower to save CPU/GPU. |
| Offscreen Pause | `IntersectionObserver` pauses the animation loop when the canvas scrolls out of view. |
| Debounced Resize | Window resize events are debounced (100 ms) to avoid layout thrashing. |
| Live Update | Changing parameters at runtime calls `update()` instead of destroying and re-creating the canvas. |

## Bug Fixes

- **`dispose()` crash at runtime:** Instance stored in `Map` was missing `animationFrameId`, `running`, and `stop()`. Fixed by storing an instance object with getter/bridge methods that access closure variables inside `init()`.
- **`update()` ignoring `waveWidth`/`opacity` changes:** `rebuildLayers()` was a closure function that `update()` could not access. Now bridged through the instance object so visual changes take effect.
- **`OnParametersSetAsync` firing on every render:** Added config hash tracking so JS `update()` is only called when parameter values actually change, not on every parent re-render.
- **`frameInterval` stale after `update()`:** `targetFps` changes via `update()` now take effect immediately since `frameInterval` is computed per-frame from `cfg.targetFps`.
- **`TargetFps` accepted 0 and negative values:** Now clamped to 1–120 in C# (`OnParametersSetAsync`) and `Math.max(1, ...)` in JS.
- **`update()` accepted arbitrary config keys:** Added allowlist validation for known config keys only.
- **`dispose()` did not set `running = false`:** Added `stop()` bridge to instance; `dispose()` calls it before cleanup.

## Documentation

- `TargetFps` added to README parameter table with docs on the Performance section
- CHANGELOG.md updated with all features and fixes for this PR
- Lifecycle comment added to `OnParametersSetAsync` explaining Blazor render ordering

## Tests Added (6 new)

| Test | What it verifies |
|------|------------------|
| `TargetFps_Is_Clamped_To_Minimum_1` | `TargetFps = 0` → clamped to 1 |
| `TargetFps_Is_Clamped_To_Maximum_120` | `TargetFps = 999` → clamped to 120 |
| `TargetFps_Negative_Is_Clamped_To_1` | `TargetFps = -10` → clamped to 1 |
| `OnParametersSetAsync_CallsUpdate_WhenConfigChanges` | Speed change triggers `update()` |
| `OnParametersSetAsync_SkipsUpdate_WhenConfigUnchanged` | Title change does not trigger `update()` |
| `OnParametersSetAsync_Handles_JSDisconnectedException` | Exception in `update()` caught silently |

**22/22 tests passing · 0 warnings · CI green ✅**