### PR TITLE
refactor: replace anonymous config object with WavyBackgroundConfig record

### DIFF
--- a/src/HeroWave/Components/WavyBackground.razor.cs
+++ b/src/HeroWave/Components/WavyBackground.razor.cs
@@ -78,29 +78,18 @@ public partial class WavyBackground : ComponentBase, IAsyncDisposable
     private string? _instanceId;
     private string? _previousConfigHash;
 
-    private object BuildConfig() => new
+    private WavyBackgroundConfig BuildConfig() => new()
     {
-        colors = Colors,
-        backgroundColor = BackgroundColor,
-        waveCount = WaveCount,
-        waveWidth = WaveWidth,
-        speed = Speed,
-        opacity = Opacity,
-        targetFps = TargetFps
+        Colors = Colors,
+        BackgroundColor = BackgroundColor,
+        WaveCount = WaveCount,
+        WaveWidth = WaveWidth,
+        Speed = Speed,
+        Opacity = Opacity,
+        TargetFps = TargetFps
     };
 
-    private string ComputeConfigHash()
-    {
-        var hash = new HashCode();
-        foreach (var c in Colors) hash.Add(c);
-        hash.Add(BackgroundColor);
-        hash.Add(WaveCount);
-        hash.Add(WaveWidth);
-        hash.Add(Speed);
-        hash.Add(Opacity);
-        hash.Add(TargetFps);
-        return hash.ToHashCode().ToString();
-    }
+    private string ComputeConfigHash() => BuildConfig().GetHashCode().ToString();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/HeroWave/Components/WavyBackgroundConfig.cs
+++ b/src/HeroWave/Components/WavyBackgroundConfig.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace HeroWave.Components;
+
+/// <summary>
+/// Strongly-typed configuration passed to the wavy-background JS module via JS interop.
+/// Property names are serialized as camelCase to match the JavaScript API contract.
+/// </summary>
+public sealed record WavyBackgroundConfig
+{
+    /// <summary>
+    /// Array of CSS color strings used for each wave.
+    /// Colors are cycled if there are fewer colors than waves.
+    /// </summary>
+    [JsonPropertyName("colors")]
+    public required string[] Colors { get; init; }
+
+    /// <summary>
+    /// Background color of the canvas.
+    /// </summary>
+    [JsonPropertyName("backgroundColor")]
+    public required string BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Number of wave lines to render.
+    /// </summary>
+    [JsonPropertyName("waveCount")]
+    public required int WaveCount { get; init; }
+
+    /// <summary>
+    /// Base stroke width of each wave in CSS pixels.
+    /// </summary>
+    [JsonPropertyName("waveWidth")]
+    public required int WaveWidth { get; init; }
+
+    /// <summary>
+    /// Animation speed. Higher values = faster waves.
+    /// </summary>
+    [JsonPropertyName("speed")]
+    public required double Speed { get; init; }
+
+    /// <summary>
+    /// Wave opacity multiplier. Controls the overall visibility of the waves.
+    /// </summary>
+    [JsonPropertyName("opacity")]
+    public required double Opacity { get; init; }
+
+    /// <summary>
+    /// Target frames per second for the animation loop.
+    /// Clamped to the range 1–120.
+    /// </summary>
+    [JsonPropertyName("targetFps")]
+    public required int TargetFps { get; init; }
+}

--- a/tests/HeroWave.Tests/WavyBackgroundTests.cs
+++ b/tests/HeroWave.Tests/WavyBackgroundTests.cs
@@ -173,10 +173,8 @@ public class WavyBackgroundTests : BunitContext
         Assert.Single(initInvocations);
         Assert.Equal(2, initInvocations[0].Arguments.Count);
 
-        var configType = initInvocations[0].Arguments[1]!.GetType();
-        var targetFpsProp = configType.GetProperty("targetFps");
-        Assert.NotNull(targetFpsProp);
-        Assert.Equal(30, targetFpsProp!.GetValue(initInvocations[0].Arguments[1]));
+        var config = Assert.IsType<WavyBackgroundConfig>(initInvocations[0].Arguments[1]);
+        Assert.Equal(30, config.TargetFps);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Replaces the anonymous object in `BuildConfig()` with a strongly-typed `WavyBackgroundConfig` record.

## Changes

- **New:** `WavyBackgroundConfig.cs` — sealed record with `[JsonPropertyName]` attributes for camelCase JS interop
- **Updated:** `WavyBackground.razor.cs` — `BuildConfig()` returns `WavyBackgroundConfig`; `ComputeConfigHash()` simplified to use record `GetHashCode()`
- **Updated:** `WavyBackgroundTests.cs` — config assertion uses `IsType<WavyBackgroundConfig>()` instead of reflection over anonymous type

## Why

| Before (anonymous) | After (record) |
|---|---|
| No compile-time contract with JS | Explicit type with `[JsonPropertyName]` mapping |
| `ComputeConfigHash()` duplicated the property list manually | `record.GetHashCode()` — single source of truth |
| Test used reflection to inspect anonymous type | Test asserts strong type directly |
| Property rename could silently break JS interop | `[JsonPropertyName]` makes the JS contract explicit |

## Verification

- ✅ Build succeeds (0 warnings, 0 errors) across net8.0/net9.0/net10.0
- ✅ All 22 unit tests pass
- ✅ All 6 E2E tests pass